### PR TITLE
Add Uptime Kuma heartbeat monitoring

### DIFF
--- a/fabaxi.py
+++ b/fabaxi.py
@@ -2,6 +2,7 @@ import logging
 import os
 import random
 
+import aiohttp
 import discord
 from discord.ext import commands, tasks
 from dotenv import load_dotenv
@@ -45,6 +46,22 @@ async def on_ready():
     await send_system_message(bot=bot, content="Bot is ready and online!")
     if not change_status.is_running():
         change_status.start()
+    if not uptime_heartbeat.is_running():
+        uptime_heartbeat.start()
+
+@tasks.loop(seconds=30)
+async def uptime_heartbeat():
+    if not bot.is_ready():
+        uptime_heartbeat.stop()
+        return
+    url = os.getenv("UPTIME_KUMA_PUSH_URL")
+    if not url:
+        return
+    try:
+        async with aiohttp.ClientSession() as session:
+            await session.get(url)
+    except Exception as e:
+        logging.warning(f"Uptime Kuma heartbeat failed: {e}")
 
 @tasks.loop(hours=12)
 async def change_status():


### PR DESCRIPTION
## Summary
- Adds a background task in `fabaxi.py` that sends a Push heartbeat to Uptime Kuma every 30 seconds
- Loop stoppt automatisch wenn der Bot seinen Discord-Login verliert (`bot.is_ready()` check) und startet bei Reconnect neu
- Push-URL wird via `UPTIME_KUMA_PUSH_URL` Env-Variable konfiguriert — kein offener Port nötig

## Test plan
- [ ] `UPTIME_KUMA_PUSH_URL` in `.env` setzen
- [ ] Bot starten und prüfen ob Uptime Kuma Monitor auf Up springt
- [ ] Bot stoppen und prüfen ob Uptime Kuma nach Timeout auf Down wechselt

🤖 Generated with [Claude Code](https://claude.com/claude-code)