### PR TITLE
Refactor default_embed, add birthday list pagination

### DIFF
--- a/app/commands/fun.py
+++ b/app/commands/fun.py
@@ -96,7 +96,7 @@ class Fun(commands.Cog): # create a class for our cog that inherits from command
             response = naasjson['reason']
 
 
-        embed: discord.Embed = await default_embed(ctx.author)
+        embed: discord.Embed = await default_embed()
         embed.title = "Magic 8ball"
         embed.set_thumbnail(url="https://cdn.pixabay.com/photo/2015/09/05/07/17/pool-ball-923833_960_720.png")
         embed.add_field(name="Question", value=question, inline=False)

--- a/app/commands/stuff.py
+++ b/app/commands/stuff.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime, timedelta, time
 
 import discord
-from discord.ext import commands, tasks
+from discord.ext import commands, pages, tasks
 from ext.system import default_embed
 
 from db import Database
@@ -106,7 +106,7 @@ class Stuff(commands.Cog):
         if user is None:
             user = ctx.author
         if user.bot: return await ctx.respond("Bots don't have birthdays.")
-        embed: discord.Embed = await default_embed(user=user)
+        embed: discord.Embed = await default_embed()
         embed.title = f"{user.display_name}'s Birthday"
         if user.avatar: embed.set_thumbnail(url=user.avatar.url)
         try:
@@ -127,32 +127,47 @@ class Stuff(commands.Cog):
         except Exception as e:
             embed.description = "An error occurred. Please try again later."
             print(e)
-        if user.color != discord.Color.default(): embed.color = user.color
-        else: embed.color = 0x1abc9c
         await ctx.respond(embed=embed)
 
     @birthdayCommandGroup.command(name="list", description="List all birthdays in the server.", contexts={discord.InteractionContextType.guild})
     async def listBirthdays(self, ctx):
-        embed: discord.Embed = await default_embed(user=ctx.author)
-        embed.title = "Birthdays in this server"
-
         try:
             birthdays = await BirthdayBackend().get_all_birthdays(ctx.guild.id)
             if not birthdays:
+                embed: discord.Embed = await default_embed()
+                embed.title = "Birthdays in this server"
                 embed.description = "No birthdays set in this server."
-            else:
-                for birthday in birthdays:
+                return await ctx.respond(embed=embed)
+
+            PAGE_SIZE = 7
+            page_list = []
+            for i in range(0, len(birthdays), PAGE_SIZE):
+                chunk = birthdays[i:i + PAGE_SIZE]
+                embed: discord.Embed = await default_embed()
+                embed.title = "Birthdays in this server"
+                for birthday in chunk:
                     user = ctx.guild.get_member(birthday.user_id)
-                    if user:
-                        birthday_date = date(birthday.year, birthday.month, birthday.day)
-                        if birthday.year == 1900:
-                            embed.add_field(name=f"{user.display_name}'s Birthday", value=f"{birthday_date.day}. {birthday_date.strftime('%B')}", inline=False)
-                        else:
-                            embed.add_field(name=f"{user.display_name}'s Birthday", value=f"{birthday_date.day}. {birthday_date.strftime('%B')} {birthday_date.year}", inline=False)
+                    if not user:
+                        continue
+                    birthday_date = date(birthday.year, birthday.month, birthday.day)
+                    if birthday.year == 1900:
+                        value = f"{birthday_date.day}. {birthday_date.strftime('%B')}"
+                    else:
+                        value = f"{birthday_date.day}. {birthday_date.strftime('%B')} {birthday_date.year}"
+                    embed.add_field(name=f"{user.display_name}'s Birthday", value=value, inline=False)
+                page_list.append(embed)
+
+            if len(page_list) == 1:
+                await ctx.respond(embed=page_list[0])
+            else:
+                paginator = pages.Paginator(pages=page_list)
+                await paginator.respond(ctx.interaction)
         except Exception as e:
+            embed: discord.Embed = await default_embed()
+            embed.title = "Birthdays in this server"
             embed.description = "An error occurred while fetching birthdays. Please try again later."
             print(e)
-        await ctx.respond(embed=embed)
+            await ctx.respond(embed=embed)
 ##############################################################
 def setup(bot):  # this is called by Pycord to setup the cog
     bot.add_cog(Stuff(bot))  # add the cog to the bot

--- a/app/events/karma.py
+++ b/app/events/karma.py
@@ -120,7 +120,7 @@ class Karma(commands.Cog):
     async def leaderboard(self, ctx):
         """Displays the leaderboard for the server."""
         await ctx.defer()
-        embed = await default_embed(user=ctx.author, fact=True)
+        embed = await default_embed()
         embed.title = "Karma Leaderboard"
         top_users = await UserKarma().get_karma_leaderboard(ctx.guild.id, 10)
 

--- a/app/temp-voice/temp-voice-comands.py
+++ b/app/temp-voice/temp-voice-comands.py
@@ -119,7 +119,7 @@ class RenameChannel(discord.ui.Modal):  # Modal for renaming the channel
                     await channel.edit(
                         name=f"🔊・{interaction.user.display_name}'s Channel")  # set the name to the default name
 
-                embed: discord.Embed = await default_embed(interaction.user)
+                embed: discord.Embed = await default_embed()
                 embed.title="Update successful!"  # set the title
                 embed.description=f"Your channel is now named {channel.name}!"  # set the description
                 embed.set_thumbnail(url="https://img.icons8.com/?size=100&id=oJQSZNne5Rp0&format=png&color=000000")
@@ -153,7 +153,7 @@ class LimitChannel(discord.ui.Modal):  # Modal for setting the user limit
         else:
             return await interaction.response.send_message("Please enter a valid number! (1 - 99)",
                                                            ephemeral=True)  # send a message that the value is not a number
-        embed: discord.Embed = await default_embed(interaction.user)
+        embed: discord.Embed = await default_embed()
         embed.title="Update successful!"  # set the title
         embed.description=f"Your channel now has a limit of {channel.user_limit}!"  # set the description
         embed.set_thumbnail(url="https://img.icons8.com/?size=100&id=2v99zq45tmel&format=png&color=000000")
@@ -178,7 +178,7 @@ class ClaimChannel(CooldownSetter): # Modal for claiming the channel
 
         await interaction.user.voice.channel.edit(name=f"🔊・{interaction.user.display_name}'s Channel")  # set the name of the channel to the member's name
 
-        embed: discord.Embed = await default_embed(interaction.user)
+        embed: discord.Embed = await default_embed()
         embed.title="Temporary voice channel claimed!"  # set the title
         embed.description="You have successfully claimed the temporary voice channel!"  # set the description
         embed.set_thumbnail(url="https://img.icons8.com/?size=100&id=2HUccuweutbu&format=png&color=000000")
@@ -194,7 +194,7 @@ class LockChannel(CooldownSetter): # Modal for locking the channel
             channel = interaction.user.voice.channel  # get the channel
             permissions = {interaction.guild.default_role: discord.PermissionOverwrite(connect=False), interaction.user: discord.PermissionOverwrite(connect=True)}
             await channel.edit(overwrites=permissions)  # set the permissions
-            embed: discord.Embed = await default_embed(interaction.user)
+            embed: discord.Embed = await default_embed()
             embed.title="Update successful!",  # set the title
             embed.description="Your temporary voice channel has been successfully locked!",  # set the description
             embed.set_thumbnail(url="https://img.icons8.com/?size=100&id=znpDNZWhQe6p&format=png&color=000000")
@@ -210,7 +210,7 @@ class UnlockChannel(CooldownSetter):  # Modal for unlocking the channel
             channel = interaction.user.voice.channel  # get the channel
             permissions = {interaction.guild.default_role: discord.PermissionOverwrite(connect=True), }
             await channel.edit(overwrites=permissions)
-            embed: discord.Embed = await default_embed(interaction.user)
+            embed: discord.Embed = await default_embed()
             embed.title="Update successful!",  # set the title
             embed.description="Your temporary voice channel has been successfully unlocked!",  # set the description
             embed.set_thumbnail(url="https://img.icons8.com/?size=100&id=bmqc7DrIxfXZ&format=png&color=000000")

--- a/db/birthdays.py
+++ b/db/birthdays.py
@@ -17,6 +17,7 @@ class BirthdayBackend(Database):
             birthdays = records.scalars().all()
             today = date.today()
 
+            # Sort birthdays by how soon they are coming up, with the closest ones first
             def days_until_next_birthday(birthday_record):
                 try:
                     this_year_birthday = date(today.year, birthday_record.month, birthday_record.day)

--- a/ext/system.py
+++ b/ext/system.py
@@ -22,12 +22,9 @@ async def send_system_message(bot: discord.Bot, content: str, alert: bool = Fals
                 await webhook.send(embed=embed, username=bot.user.name, content="<@!327880195476422656> <@!474947907913515019>")
             else: await webhook.send(embed=embed, username=bot.user.name)
 # default embed generator for commands which sets the user's color and adds a random fact to the footer (if fact=True)
-async def default_embed(user: discord.User, fact: bool = True):
+async def default_embed(fact: bool = True):
     embed = discord.Embed()
-    if user.color != discord.Color.default():
-        embed.color = user.color
-    else:
-        embed.color = 0x1abc9c
+    embed.color = 0x1abc9c
     if fact:
         async with aiohttp.ClientSession() as session:
             async with session.get("https://uselessfacts.jsph.pl/api/v2/facts/random?language=en") as response:


### PR DESCRIPTION
## Changes

### `default_embed` refactoring
The `default_embed` helper in `ext/system.py` previously accepted a `user` parameter to apply the user's role color to the embed. This has been removed — all embeds now consistently use the fixed hex color `0x1abc9c`. All call sites across the codebase have been updated accordingly:

- `app/commands/fun.py`
- `app/commands/stuff.py`
- `app/events/karma.py`
- `app/temp-voice/temp-voice-comands.py`

The leftover manual color-override block in `viewBirthday` (which re-applied the same logic after calling `default_embed`) has also been removed.

### Birthday list pagination
The `/birthday list` command now paginates results using Pycord's built-in `discord.ext.pages.Paginator`. Servers with more than 7 birthdays will see multiple pages with Previous/Next buttons instead of a single oversized embed. For 7 or fewer entries the behavior is unchanged (plain embed, no buttons).

### Birthday sorting comment
Added a clarifying comment to `db/birthdays.py` above the sorting function that orders birthdays by how soon they are coming up.