### PR TITLE
Refactor karma, setups, and temp voice embed fixes

### DIFF
--- a/app/events/karma.py
+++ b/app/events/karma.py
@@ -27,12 +27,14 @@ class Karma(commands.Cog):
 
     @discord.Cog.listener()
     async def on_message(self, message: discord.Message):
-        if (message.author.bot or message.channel.id == 1229062537954332782 or  # commands channel
-                message.channel.id == 1337733289695514725 or  # counting channel
-                message.channel.id == 1339010562964586647 or  # cult leader channel
-                message.channel.id == 1283842433284837396  # burgeramt channel
-        ):
-            return
+        ignored_channels = [
+            1229062537954332782,  # commands channel
+            1337733289695514725,  # counting channel
+            1339010562964586647,  # cult leader channel
+            1462546344064586031,  # guess the number channel
+            1283842433284837396,  # burgeramt channel
+        ]
+        if (message.author.bot or message.channel.id in ignored_channels): return
 
         await UserKarma().handle_message_karma(user_id=message.author.id, guild_id=message.guild.id,
             timestamp=message.created_at.timestamp(), )

--- a/app/events/setups.py
+++ b/app/events/setups.py
@@ -18,7 +18,11 @@ class Setups(commands.Cog): # create a class for our cog that inherits from comm
 
     @commands.Cog.listener() # we can add event listeners to our cog
     async def on_member_join(self, member): # this is called when a member joins the server
-        role_ids = [1230984456186237008, 1229073628658794688, 1341774758076874832]  
+        role_ids = [
+            1230984456186237008, # Interests role
+            1229073628658794688, # About Me role
+            1341774758076874832  # Custom Roles role
+        ]  
         for role_id in role_ids:
             role = discord.utils.get(member.guild.roles, id=role_id)
             await member.add_roles(role)

--- a/app/temp-voice/temp-voice-comands.py
+++ b/app/temp-voice/temp-voice-comands.py
@@ -195,8 +195,8 @@ class LockChannel(CooldownSetter): # Modal for locking the channel
             permissions = {interaction.guild.default_role: discord.PermissionOverwrite(connect=False), interaction.user: discord.PermissionOverwrite(connect=True)}
             await channel.edit(overwrites=permissions)  # set the permissions
             embed: discord.Embed = await default_embed()
-            embed.title="Update successful!",  # set the title
-            embed.description="Your temporary voice channel has been successfully locked!",  # set the description
+            embed.title="Update successful!"  # set the title
+            embed.description="Your temporary voice channel has been successfully locked!"  # set the description
             embed.set_thumbnail(url="https://img.icons8.com/?size=100&id=znpDNZWhQe6p&format=png&color=000000")
             await interaction.response.send_message(embed=embed, ephemeral=True)  # send the embed
 
@@ -211,8 +211,8 @@ class UnlockChannel(CooldownSetter):  # Modal for unlocking the channel
             permissions = {interaction.guild.default_role: discord.PermissionOverwrite(connect=True), }
             await channel.edit(overwrites=permissions)
             embed: discord.Embed = await default_embed()
-            embed.title="Update successful!",  # set the title
-            embed.description="Your temporary voice channel has been successfully unlocked!",  # set the description
+            embed.title="Update successful!"  # set the title
+            embed.description="Your temporary voice channel has been successfully unlocked!"  # set the description
             embed.set_thumbnail(url="https://img.icons8.com/?size=100&id=bmqc7DrIxfXZ&format=png&color=000000")
             await interaction.response.send_message(embed=embed, ephemeral=True)  # send the embed
 


### PR DESCRIPTION
## Changes

**Karma event (`app/events/karma.py`)**
The ignored-channel check was refactored from inline conditions into a named list for better readability. The "guess the number" channel (ID `1462546344064586031`) was also added to the ignored list so messages there no longer award karma.

**Setups event (`app/events/setups.py`)**
The role IDs assigned on member join are now written as a multi-line list with inline comments explaining what each role represents (Interests, About Me, Custom Roles).

**Temp voice commands (`app/temp-voice/temp-voice-comands.py`)**
Fixed a bug where `embed.title` and `embed.description` assignments in both `LockChannel` and `UnlockChannel` had trailing commas, which silently turned the assignments into tuples and caused the embed fields to not be set correctly. The commas have been removed.