### PR TITLE
Fix unclosed HTTP connections in uptime heartbeat

### DIFF
--- a/fabaxi.py
+++ b/fabaxi.py
@@ -59,7 +59,8 @@ async def uptime_heartbeat():
         return
     try:
         async with aiohttp.ClientSession() as session:
-            await session.get(url)
+            async with session.get(url):
+                pass
     except Exception as e:
         logging.warning(f"Uptime Kuma heartbeat failed: {e}")
 


### PR DESCRIPTION
## Changes

**Uptime heartbeat fix (`fabaxi.py`)**
The `uptime_heartbeat` task was calling `await session.get(url)` without using the response as a context manager. This left the underlying HTTP connection open after each heartbeat request instead of closing it cleanly, causing repeated "Unclosed connection" warnings in the logs. The fix wraps the `session.get(url)` call in `async with` so the response — and with it the connection — is properly closed after each ping.