### PR TITLE
Fix Docker deployment failing due to stale network endpoint

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -47,6 +47,7 @@ jobs:
           docker load -i /home/fabaxi/image.tar
           docker stop ${{ secrets.DOCKER_IMAGE_NAME }} || true
           docker rm ${{ secrets.DOCKER_IMAGE_NAME }} || true
+          docker network disconnect -f bridge ${{ secrets.DOCKER_IMAGE_NAME }} || true
           docker run -d \
             --env-file /home/fabaxi/fabaxi.env \
             --restart unless-stopped \


### PR DESCRIPTION
## Changes

**CI/CD Workflow fix (`.github/workflows/docker-image.yml`)**
When the container crashed unexpectedly (as seen with the 3 outages today), Docker did not clean up the network endpoint in the bridge network. On the next deployment, `docker stop` and `docker rm` would silently fail (container already gone), but `docker run` would then crash with `failed to set up container networking: endpoint with name *** already exists in network bridge` because the stale network entry was still registered.

Added `docker network disconnect -f bridge <name> || true` between the remove and run steps to forcefully clear any leftover network endpoint before starting the new container. The `|| true` ensures the step does not fail when no stale endpoint is present (the normal case).