### PR TITLE
Add REST API server for bot integration

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,161 @@
+# Fabaxi REST API
+
+Lokaler HTTP-Server der parallel zum Discord-Bot läuft.  
+Startet automatisch beim Bot-Start auf dem in `.env` konfigurierten Port.
+
+---
+
+## Authentifizierung
+
+Alle Endpunkte erfordern einen Bearer-Token im `Authorization`-Header:
+
+```
+Authorization: Bearer <API_SECRET>
+```
+
+Der `API_SECRET` wird in `.env` gesetzt. Fehlt der Header oder ist der Token falsch, antwortet die API mit `401 Unauthorized`.
+
+---
+
+## Endpunkte
+
+### `POST /api/dm` — DM als Embed senden
+
+Sendet einem Discord-Nutzer eine Direktnachricht als Embed.
+
+**URL**
+```
+POST http://localhost:62299/api/dm
+```
+
+**Headers**
+| Header | Wert |
+|---|---|
+| `Authorization` | `Bearer <API_SECRET>` |
+| `Content-Type` | `application/json` |
+
+**Request Body**
+
+```json
+{
+  "user_id": 327880195476422656,
+  "embed": {
+    "title": "Dein Titel",
+    "description": "Der Haupttext der Nachricht.",
+    "color": 1752220,
+    "fields": [
+      { "name": "Feld 1", "value": "Inhalt 1", "inline": false },
+      { "name": "Feld 2", "value": "Inhalt 2", "inline": true }
+    ],
+    "footer": "Fußzeile",
+    "image_url": "https://example.com/bild.png",
+    "thumbnail_url": "https://example.com/thumb.png"
+  }
+}
+```
+
+**Felder**
+
+| Feld | Typ | Pflicht | Beschreibung |
+|---|---|---|---|
+| `user_id` | integer | ✅ | Discord User-ID des Empfängers |
+| `embed` | object | ✅ | Das Embed-Objekt |
+| `embed.title` | string | ❌ | Titel des Embeds |
+| `embed.description` | string | ❌ | Haupttext |
+| `embed.color` | integer | ❌ | Farbe als Dezimalzahl (Standard: `0x1abc9c`) |
+| `embed.fields` | array | ❌ | Liste von Feldern (name, value, inline) |
+| `embed.footer` | string | ❌ | Fußzeile |
+| `embed.image_url` | string | ❌ | Großes Bild unten im Embed |
+| `embed.thumbnail_url` | string | ❌ | Kleines Bild oben rechts |
+
+> **Hinweis:** `embed.title` oder `embed.description` sollte mindestens eins gesetzt sein, sonst ist das Embed leer.
+
+**Antworten**
+
+| Status | Body | Bedeutung |
+|---|---|---|
+| `200` | `{"success": true}` | DM erfolgreich gesendet |
+| `400` | `{"error": "..."}` | Pflichtfelder fehlen oder kein valides JSON |
+| `401` | `{"error": "Unauthorized"}` | Falscher oder fehlender Bearer-Token |
+| `403` | `{"error": "Cannot send DM to this user"}` | Nutzer hat DMs deaktiviert |
+| `404` | `{"error": "User not found"}` | User-ID existiert nicht |
+| `500` | `{"error": "..."}` | Discord-API-Fehler |
+
+---
+
+## Beispiele
+
+### cURL
+
+```bash
+curl -X POST http://localhost:62299/api/dm \
+  -H "Authorization: Bearer <API_SECRET>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "user_id": 327880195476422656,
+    "embed": {
+      "title": "Hallo!",
+      "description": "Das ist eine automatische Nachricht.",
+      "color": 1752220
+    }
+  }'
+```
+
+### Python (`httpx`)
+
+```python
+import httpx
+
+response = httpx.post(
+    "http://localhost:62299/api/dm",
+    headers={"Authorization": "Bearer <API_SECRET>"},
+    json={
+        "user_id": 327880195476422656,
+        "embed": {
+            "title": "Hallo!",
+            "description": "Das ist eine automatische Nachricht.",
+            "color": 1752220,
+            "fields": [
+                {"name": "Status", "value": "Aktiv", "inline": True}
+            ],
+            "footer": "Fabaxi Bot"
+        }
+    }
+)
+print(response.json())
+```
+
+### JavaScript (`fetch`)
+
+```js
+await fetch("http://localhost:62299/api/dm", {
+  method: "POST",
+  headers: {
+    "Authorization": "Bearer <API_SECRET>",
+    "Content-Type": "application/json"
+  },
+  body: JSON.stringify({
+    user_id: 327880195476422656,
+    embed: {
+      title: "Hallo!",
+      description: "Das ist eine automatische Nachricht.",
+      color: 1752220
+    }
+  })
+});
+```
+
+---
+
+## Farbwerte (Dezimal)
+
+Discord-Embed-Farben werden als Dezimalzahl übergeben. Umrechnung: `parseInt("1abc9c", 16)`.
+
+| Farbe | Hex | Dezimal |
+|---|---|---|
+| Türkis (Standard) | `#1abc9c` | `1752220` |
+| Blau | `#3498db` | `3447003` |
+| Rot | `#e74c3c` | `15158332` |
+| Grün | `#2ecc71` | `3066993` |
+| Gelb | `#f1c40f` | `15844367` |
+| Grau | `#95a5a6` | `9807270` |

--- a/ext/api.py
+++ b/ext/api.py
@@ -1,0 +1,104 @@
+import logging
+import os
+
+import aiohttp.web
+import discord
+
+
+async def _build_embed(data: dict) -> discord.Embed:
+    embed = discord.Embed(
+        title=data.get("title"),
+        description=data.get("description"),
+    )
+    color = data.get("color")
+    if color is not None:
+        embed.color = int(color)
+    else:
+        embed.color = 0x1abc9c
+
+    for field in data.get("fields", []):
+        embed.add_field(
+            name=field.get("name", ""),
+            value=field.get("value", ""),
+            inline=field.get("inline", False),
+        )
+
+    if footer := data.get("footer"):
+        embed.set_footer(text=footer)
+    if image_url := data.get("image_url"):
+        embed.set_image(url=image_url)
+    if thumbnail_url := data.get("thumbnail_url"):
+        embed.set_thumbnail(url=thumbnail_url)
+
+    return embed
+
+
+def create_app(bot: discord.Bot) -> aiohttp.web.Application:
+    api_secret = os.getenv("API_SECRET")
+    app = aiohttp.web.Application()
+
+    def _auth(request: aiohttp.web.Request) -> bool:
+        if not api_secret:
+            return False
+        auth = request.headers.get("Authorization", "")
+        return auth == f"Bearer {api_secret}"
+
+    async def send_dm(request: aiohttp.web.Request) -> aiohttp.web.Response:
+        if not _auth(request):
+            return aiohttp.web.json_response({"error": "Unauthorized"}, status=401)
+
+        try:
+            body = await request.json()
+        except Exception:
+            return aiohttp.web.json_response({"error": "Invalid JSON"}, status=400)
+
+        user_id = body.get("user_id")
+        embed_data = body.get("embed")
+
+        if not user_id:
+            return aiohttp.web.json_response({"error": "user_id is required"}, status=400)
+        if not embed_data or not isinstance(embed_data, dict):
+            return aiohttp.web.json_response({"error": "embed object is required"}, status=400)
+
+        try:
+            user = await bot.fetch_user(int(user_id))
+        except discord.NotFound:
+            return aiohttp.web.json_response({"error": "User not found"}, status=404)
+        except discord.HTTPException as e:
+            logging.warning(f"API /dm fetch_user failed: {e}")
+            return aiohttp.web.json_response({"error": "Failed to fetch user"}, status=500)
+
+        try:
+            embed = await _build_embed(embed_data)
+            await user.send(embed=embed)
+        except discord.Forbidden:
+            return aiohttp.web.json_response({"error": "Cannot send DM to this user"}, status=403)
+        except discord.HTTPException as e:
+            logging.warning(f"API /dm send failed: {e}")
+            return aiohttp.web.json_response({"error": "Failed to send DM"}, status=500)
+
+        logging.info(f"API: DM sent to user {user_id}")
+        return aiohttp.web.json_response({"success": True})
+
+    app.router.add_post("/api/dm", send_dm)
+    return app
+
+
+class ApiServer:
+    def __init__(self, bot: discord.Bot):
+        self._bot = bot
+        self._runner: aiohttp.web.AppRunner | None = None
+
+    async def start(self):
+        port = int(os.getenv("API_PORT", "8080"))
+        app = create_app(self._bot)
+        self._runner = aiohttp.web.AppRunner(app)
+        await self._runner.setup()
+        site = aiohttp.web.TCPSite(self._runner, "0.0.0.0", port)
+        await site.start()
+        logging.warning(f"API server listening on port {port}")
+
+    async def stop(self):
+        if self._runner:
+            await self._runner.cleanup()
+            self._runner = None

--- a/fabaxi.py
+++ b/fabaxi.py
@@ -9,6 +9,7 @@ from dotenv import load_dotenv
 
 from ext.cache import load_random_status
 from ext.system import send_system_message
+from ext.api import ApiServer
 from db import Database
 
 
@@ -28,6 +29,8 @@ if environment == 'PROD':
 else:
     TOKEN = os.getenv('DEV_TOKEN')
     bot = commands.Bot(command_prefix='!', debug_guilds=[os.getenv("DEV_SERVER")], intents=intents)
+
+_api_server = ApiServer(bot)
 ##########################################################################
 logging.basicConfig(level=logging.WARN, format='%(asctime)s %(message)s', handlers=[logging.StreamHandler()])
 ##########################################################################
@@ -41,13 +44,21 @@ async def on_ready():
     print(bot.user.id)
     print('--------------------------------------')
     logging.info(f"{bot.user} is ready and online!")
-    await Database().init_db()
-    logging.info("Database initialized!")
+    try:
+        await Database().init_db()
+        logging.info("Database initialized!")
+    except Exception as e:
+        logging.warning(f"Database connection failed: {e}")
     await send_system_message(bot=bot, content="Bot is ready and online!")
+    await _api_server.start()
     if not change_status.is_running():
         change_status.start()
     if not uptime_heartbeat.is_running():
         uptime_heartbeat.start()
+
+@bot.event
+async def on_close():
+    await _api_server.stop()
 
 @tasks.loop(seconds=30)
 async def uptime_heartbeat():

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ cffi==2.0.0
 charset-normalizer==3.4.7
 click==8.4.1
 colorama==0.4.6
-cryptography==48.0.0
+cryptography==48.0.1
 distro==1.9.0
 dotenv==0.9.9
 frozenlist==1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ cffi==2.0.0
 charset-normalizer==3.4.7
 click==8.4.1
 colorama==0.4.6
-cryptography==48.0.0
+cryptography==49.0.0
 distro==1.9.0
 dotenv==0.9.9
 frozenlist==1.8.0
@@ -24,7 +24,7 @@ jiter==0.15.0
 joblib==1.5.3
 multidict==6.7.1
 nltk==3.9.4
-openai==2.41.0
+openai==2.41.1
 propcache==0.5.2
 py-cord @ git+https://github.com/Pycord-Development/pycord.git@1c65fc820b7faf7c02041b14ef43ed28ac18a24c
 pycparser==3.0
@@ -35,7 +35,7 @@ regex==2026.5.9
 requests==2.34.2
 sniffio==1.3.1
 SQLAlchemy==2.0.50
-tqdm==4.68.1
+tqdm==4.68.2
 typing-inspection==0.4.2
 typing_extensions==4.15.0
 urllib3==2.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ aiosignal==1.4.0
 annotated-types==0.7.0
 anyio==4.13.0
 attrs==26.1.0
-audioop-lts==0.2.2
 certifi==2026.5.20
 cffi==2.0.0
 charset-normalizer==3.4.7


### PR DESCRIPTION
## Changes

### New: REST API Server (`ext/api.py`)

A local HTTP server that runs alongside the Discord bot and enables external services to interact with it programmatically. The server authenticates all requests via a Bearer token (`API_SECRET` from `.env`).

**Endpoint added: `POST /api/dm`**

Sends a Discord DM to a user as an embed. Supports title, description, color, fields, footer, image, and thumbnail. Returns structured JSON responses for all success and error cases (200, 400, 401, 403, 404, 500).

### Bot integration (`fabaxi.py`)

- `ApiServer` is initialized at startup and started inside `on_ready` after the database is initialized.
- The API server is gracefully shut down in a new `on_close` event handler.
- Database initialization errors are now caught and logged as warnings instead of crashing the bot on startup.

### Documentation (`API.md`)

Full API reference added with endpoint specification, request/response formats, field descriptions, and usage examples in cURL, Python (`httpx`), and JavaScript (`fetch`). Also includes a color reference table for Discord embed colors.

### Dependency updates (`requirements.txt`)

- Removed `audioop-lts` (no longer needed on Python 3.13)
- `cryptography` 48.0.0 → 49.0.0
- `openai` 2.41.0 → 2.41.1
- `tqdm` 4.68.1 → 4.68.2