### PR TITLE
Expose API port in Dockerfile and CI deploy

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -52,4 +52,5 @@ jobs:
             --env-file /home/fabaxi/fabaxi.env \
             --restart unless-stopped \
             -v /home/fabaxi/db:/db \
+            -p 62299:62299 \
             --name ${{ secrets.DOCKER_IMAGE_NAME }} ${{ secrets.DOCKER_IMAGE_NAME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,10 @@ WORKDIR /bot
 RUN apt-get update && apt-get install -y git
 RUN pip install -r requirements.txt
 ENV DOCKER=true
-ENV STATUS_UPDATE_PORT=7958
+ENV API_PORT=62299
 
 VOLUME ["/db"]
-EXPOSE 7958
+EXPOSE 62299
 
 ENTRYPOINT ["python", "fabaxi.py"]
 


### PR DESCRIPTION
## Changes

### Dockerfile

Replaced the old `STATUS_UPDATE_PORT` (7958) with the REST API port. `ENV API_PORT=62299` sets the default port the API server binds to, and `EXPOSE 62299` documents it for Docker.

### CI Deploy Workflow (`.github/workflows/docker-image.yml`)

Added `-p 62299:62299` to the `docker run` command so the API port is actually mapped to the host on every deploy. Without this, the container started successfully but the API was unreachable from outside.