### PR TITLE
fix: Bitrate-Logik für geboostete Server korrigiert

### DIFF
--- a/app/temp-voice/temp-voice.py
+++ b/app/temp-voice/temp-voice.py
@@ -69,10 +69,10 @@ async def createTempVoice(bot, joinToCreateParent, member: discord.Member):
     category = bot.get_channel(joinToCreateParent)  # get the category
     channel: discord.VoiceChannel = await category.create_voice_channel(f"🔊・{member.display_name}'s Channel", user_limit=10)  # create the channel with 10 slots
     if member.guild.premium_tier == 3: await channel.edit(bitrate=384000)  # if the server is boosted to level 3, set the bitrate to 384kbps
-    if member.guild.premium_tier == 2: await channel.edit(bitrate=256000)  # if the server is boosted to level 2, set the bitrate to 256kbps
-    if member.guild.premium_tier == 1: await channel.edit(bitrate=128000)  # if the server is boosted to level 1, set the bitrate to 128kbps
+    elif member.guild.premium_tier == 2: await channel.edit(bitrate=256000)  # if the server is boosted to level 2, set the bitrate to 256kbps
+    elif member.guild.premium_tier == 1: await channel.edit(bitrate=128000)  # if the server is boosted to level 1, set the bitrate to 128kbps
     else: await channel.edit(bitrate=96000)  # if the server is not boosted, set the bitrate to 96kbps
-    # await TempVoiceBackend().create_temp_voice(member.id, channel.id, member.guild.id)  # save the channel id to the database
+    await TempVoiceBackend().create_temp_voice(member.id, channel.id, member.guild.id)  # save the channel id to the database
     await member.move_to(channel)  # move the member to the channel
     return channel
 


### PR DESCRIPTION
## Changes

### Bug Fix: Temp Voice Bitrate Override

The bitrate conditions in `createTempVoice` used `if` instead of `elif`, causing the `else` branch (96 kbps) to always execute after the tier 3 check — overwriting the correct 384 kbps with 96 kbps on level 3 boosted servers.

Changed the second and third conditions from `if` to `elif` so only one bitrate is applied per call. Also re-enabled the database call to `TempVoiceBackend().create_temp_voice()` that was accidentally left commented out.